### PR TITLE
feat: add shell.nix for quick nix dev environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,22 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  zig = pkgs.zig;
+in
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    (python3.withPackages (ps: with ps; [
+      numpy
+      safetensors
+      torch
+      torchvision
+    ]))
+    stdenv.cc.cc.lib
+    zig
+  ];
+
+  shellHook = ''
+    export LD_LIBRARY_PATH=${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH
+  '';
+}
+


### PR DESCRIPTION
Adds a shell.nix to the root directory, users with `nix` installed now can just run:

```
nix-shell
```